### PR TITLE
remove unuseful callback

### DIFF
--- a/src/Onion.php
+++ b/src/Onion.php
@@ -84,7 +84,7 @@ class Onion {
     private function createCoreFunction(Closure $core)
     {
         return function($object) use($core) {
-            return call_user_func($core, $object);
+            return $core($object);
         };
     }
 
@@ -98,7 +98,7 @@ class Onion {
     private function createLayer($nextLayer, $layer)
     {
         return function($object) use($nextLayer, $layer){
-            return call_user_func_array([$layer, 'peel'], [$object, $nextLayer]);
+            return $layer->peel($object, $nextLayer);
         };
     }
 


### PR DESCRIPTION
Thanks you for the simple and good example, here's my contribution. There's no point to call member functions with callback.